### PR TITLE
Update Star History chart URLs and remove sealed tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ If Servers@Home has saved you time or helped your homelab, here's how to give ba
 ## 🌟 Star History
 <a href="https://www.star-history.com/?repos=serversathome%2FServersatHome&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=serversathome/ServersatHome&type=date&theme=dark&legend=top-left&sealed_token=SQiJx_9gJ7JW2kaJWchjUicOsFzszDY6vGI0_5esFCJDwuJgVYlQlNjDljlrLF-ysT1CtrS1IaM-32AVSsN4t9zBjbk5vhL2RblOsqVKablRW5GTo6vM6VkQyXMnuRPIr_TqqYdPNpXWqU2nQ2H1ErGbYa--anWnYtg4I5oXl12zIl5OdupmQnpHWpSg" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=serversathome/ServersatHome&type=date&legend=top-left&sealed_token=SQiJx_9gJ7JW2kaJWchjUicOsFzszDY6vGI0_5esFCJDwuJgVYlQlNjDljlrLF-ysT1CtrS1IaM-32AVSsN4t9zBjbk5vhL2RblOsqVKablRW5GTo6vM6VkQyXMnuRPIr_TqqYdPNpXWqU2nQ2H1ErGbYa--anWnYtg4I5oXl12zIl5OdupmQnpHWpSg" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=serversathome/ServersatHome&type=date&legend=top-left&sealed_token=SQiJx_9gJ7JW2kaJWchjUicOsFzszDY6vGI0_5esFCJDwuJgVYlQlNjDljlrLF-ysT1CtrS1IaM-32AVSsN4t9zBjbk5vhL2RblOsqVKablRW5GTo6vM6VkQyXMnuRPIr_TqqYdPNpXWqU2nQ2H1ErGbYa--anWnYtg4I5oXl12zIl5OdupmQnpHWpSg" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=serversathome%2Fserversathome&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=serversathome%2Fserversathome&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=serversathome%2Fserversathome&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
## Summary
Updated the Star History chart URLs in the README to use the current repository naming convention and removed sealed tokens from the image sources.

## Key Changes
- Updated repository path from `serversathome/ServersatHome` to `serversathome/serversathome` (lowercase) in all three chart URL sources
- Removed `sealed_token` parameters from dark mode, light mode, and fallback image URLs
- Simplified URLs by removing unnecessary query parameters while maintaining core functionality (type, theme, and legend settings)

## Details
The changes ensure that the Star History chart displays correctly with the proper repository identifier and removes deprecated/unnecessary authentication tokens from the public URLs. This makes the URLs cleaner and more maintainable while preserving the chart's appearance across different color schemes.

https://claude.ai/code/session_01LcRGc1MZCEc6bsjYPzGRAb